### PR TITLE
Change the format of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Over the past years, YOLOs have emerged as the predominant paradigm in the field
 
 ## Performance
 COCO
+
 | Model | Test Size | #Params | FLOPs | AP<sup>val</sup> | Latency |
 |:---------------|:----:|:---:|:--:|:--:|:--:|
 | [YOLOv10-N](https://github.com/THU-MIG/yolov10/releases/download/v1.1/yolov10n.pt) |   640  |     2.3M    |   6.7G   |     38.5%     | 1.84ms |


### PR DESCRIPTION
In some strict markdown format renderers, some errors may occur. I have fixed this issue to make the readme file adhere more strictly to the markdown syntax rules.


<img width="2169" alt="image" src="https://github.com/THU-MIG/yolov10/assets/22064617/f99d36bd-42c8-4ea6-8bff-bd9f8104da30">
