### PR TITLE
Quickly Experience YOLOv10 on Jetson

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Over the past years, YOLOs have emerged as the predominant paradigm in the field
 </details>
 
 **UPDATES** 🔥
+- 2024/05/31: Build [yolov10-jetson](https://github.com/Seeed-Projects/jetson-examples/blob/main/reComputer/scripts/yolov10/README.md) docker image by [youjiang](https://github.com/yuyoujiang)!
 - 2024/05/31: Thanks to [mohamedsamirx](https://github.com/mohamedsamirx) for the integration with [BoTSORT, DeepOCSORT, OCSORT, HybridSORT, ByteTrack, StrongSORT using BoxMOT library](https://colab.research.google.com/drive/1-QV2TNfqaMsh14w5VxieEyanugVBG14V?usp=sharing)!
 - 2024/05/31: Thanks to [kaylorchen](https://github.com/kaylorchen) for the integration with [rk3588](https://github.com/kaylorchen/rk3588-yolo-demo)!
 - 2024/05/31: Please use the [exported format](https://github.com/THU-MIG/yolov10?tab=readme-ov-file#export) for benchmark. In the non-exported format, e.g., pytorch, the speed of YOLOv10 is biased because the unnecessary `cv2` and `cv3` operations in the `v10Detect` are executed during inference.


### PR DESCRIPTION
Hello, I have build a Docker image for Jetson (a high-performance edge computing device), which facilitates Jetson users in quickly utilizing the YOLOv10 algorithm.
project address: https://github.com/Seeed-Projects/jetson-examples/blob/main/reComputer/scripts/yolov10/README.md
![yolov10_on_jetson](https://github.com/THU-MIG/yolov10/assets/76863444/cd92aab9-952b-4426-9a08-c3762673a6af)
