### PR TITLE
Make postprocessing compatible with nobuco

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -852,12 +852,12 @@ def v10postprocess(preds, max_det, nc=80):
     assert(4 + nc == preds.shape[-1])
     boxes, scores = preds.split([4, nc], dim=-1)
     max_scores = scores.amax(dim=-1)
-    max_scores, index = torch.topk(max_scores, max_det, axis=-1)
+    max_scores, index = torch.topk(max_scores, max_det, dim=-1)
     index = index.unsqueeze(-1)
     boxes = torch.gather(boxes, dim=1, index=index.repeat(1, 1, boxes.shape[-1]))
     scores = torch.gather(scores, dim=1, index=index.repeat(1, 1, scores.shape[-1]))
 
-    scores, index = torch.topk(scores.flatten(1), max_det, axis=-1)
+    scores, index = torch.topk(scores.flatten(1), max_det, dim=-1)
     labels = index % nc
     index = index // nc
     boxes = boxes.gather(dim=1, index=index.unsqueeze(-1).repeat(1, 1, boxes.shape[-1]))


### PR DESCRIPTION
There are 2 changes that allow the post-processing to be compatible with Nobuco (https://github.com/AlexanderLutsenko/nobuco), a PyTorch to Tensorflow converter.

They are as follows:
1) Use `dim` instead of `axis` for PyTorch functions.
2) Make sure that the labels have the same type as the boxes and scores (so that when they're concatenated everything has the same dtype).

With these changes I was able to run YOLOv10 in my web/mobile app CameraChess (https://www.camerachess.com)

Thank you for your contributions to the field :)