### PR TITLE
fix cv2.error when use PIL.Image.Image

### DIFF
--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -375,6 +375,9 @@ class BasePredictor:
 
         # Save images
         else:
+            if save_path.split("/")[-1].startswith("predict"):
+                # havn't provide file name
+                save_path = save_path + "/tmp.jpg"
             cv2.imwrite(save_path, im)
 
     def show(self, p=""):

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -345,7 +345,8 @@ class BasePredictor:
         if self.args.show:
             self.show(str(p))
         if self.args.save:
-            self.save_predicted_images(str(self.save_dir / p.name), frame)
+            
+            self.save_predicted_images(str(self.save_dir / (p.name or "tmp.jpg")), frame)
 
         return string
 
@@ -375,9 +376,6 @@ class BasePredictor:
 
         # Save images
         else:
-            if save_path.split("/")[-1].startswith("predict"):
-                # havn't provide file name
-                save_path = save_path + "/tmp.jpg"
             cv2.imwrite(save_path, im)
 
     def show(self, p=""):

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -345,7 +345,6 @@ class BasePredictor:
         if self.args.show:
             self.show(str(p))
         if self.args.save:
-            
             self.save_predicted_images(str(self.save_dir / (p.name or "tmp.jpg")), frame)
 
         return string


### PR DESCRIPTION
The program will return `cv2.error: OpenCV(4.9.0) /io/opencv/modules/imgcodecs/src/loadsave.cpp:696: error: (-2:Unspecified error) could not find a writer for the specified extension in function 'imwrite_'` when use PIL.Image.Image.

This is an example

```python3
from io import BytesIO
from PIL import Image
from ultralytics import YOLOv10

model_path = "yolov10x.pt"
with open("ultralytics/assets/bus.jpg", "rb") as f:
    img_bytes = BytesIO(f.read())
model = YOLOv10(model_path)
image = Image.open(img_bytes)
model.predict(source=image, imgsz=512, conf=0.25, save=True)
```