### PR TITLE
fix issue : 'dict' object has no attribute 'shape' when predict in PyTorch model

### DIFF
--- a/ultralytics/utils/ops.py
+++ b/ultralytics/utils/ops.py
@@ -210,6 +210,10 @@ def non_max_suppression(
     # Checks
     assert 0 <= conf_thres <= 1, f"Invalid Confidence threshold {conf_thres}, valid values are between 0.0 and 1.0"
     assert 0 <= iou_thres <= 1, f"Invalid IoU {iou_thres}, valid values are between 0.0 and 1.0"
+
+    if isinstance(prediction, dict) and 'one2one' in prediction:  # model.pt, output = {"one2many": torch.Tensor, "one2one": torch.Tensor }
+        prediction = prediction['one2one']
+
     if isinstance(prediction, (list, tuple)):  # YOLOv8 model in validation model, output = (inference_out, loss_out)
         prediction = prediction[0]  # select only inference output
 


### PR DESCRIPTION
A small fix with `non_max_suppression` in `ops.py` .
The fix originated from the ultralytics issue 13587
[issues:13587](https://github.com/ultralytics/ultralytics/issues/13587)