### PR TITLE
add seaborn in requirements.txt  (#254)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ psutil==5.9.8
 py-cpuinfo==9.0.0
 huggingface-hub==0.23.2
 safetensors==0.4.3
+seaborn>=0.11.0


### PR DESCRIPTION
In some cases, failing/cannot to execute `pip install -e .` can lead to the seaborn package being missing. Therefore, when installing from requirements, it is necessary to explicitly prompt for the installation of seaborn. The specific version number referenced is from the yolov9 project as well as the pyproject.toml file.