### PR TITLE
Removed redundant assignment in attention block

### DIFF
--- a/ultralytics/nn/modules/block.py
+++ b/ultralytics/nn/modules/block.py
@@ -776,7 +776,7 @@ class Attention(nn.Module):
         self.head_dim = dim // num_heads
         self.key_dim = int(self.head_dim * attn_ratio)
         self.scale = self.key_dim ** -0.5
-        nh_kd = nh_kd = self.key_dim * num_heads
+        nh_kd = self.key_dim * num_heads
         h = dim + nh_kd * 2
         self.qkv = Conv(dim, h, 1, act=False)
         self.proj = Conv(dim, dim, 1, act=False)


### PR DESCRIPTION
`nh_kd = nk_kd = self.key_dim ** -0.5`
Removed the redundant assignment to:
`nh_kd = self.key_dim ** -0.5`