### PR TITLE
Fix "AttributeError: module 'ray.tune' has no attribute 'is_session_enabled'" (@jnx03) 

### DIFF
--- a/ultralytics/utils/callbacks/raytune.py
+++ b/ultralytics/utils/callbacks/raytune.py
@@ -14,7 +14,7 @@ except (ImportError, AssertionError):
 
 def on_fit_epoch_end(trainer):
     """Sends training metrics to Ray Tune at end of each epoch."""
-    if ray.tune.is_session_enabled():
+    if ray.train._internal.session.get_session():
         metrics = trainer.metrics
         metrics["epoch"] = trainer.epoch
         session.report(metrics)


### PR DESCRIPTION
This pull request resolves an `AttributeError` encountered during training when using newer versions of Ray. The error occurred because the callback in `ultralytics/utils/callbacks/raytune.py` was calling the deprecated method `_get_session()` (which has been removed or renamed in recent Ray releases) instead of the updated `get_session()`.

**Error come from google colab and kaggle notebook**

Error Log
```
Traceback (most recent call last):
  File "/usr/local/bin/yolo", line 8, in <module>
    sys.exit(entrypoint())
  File "/usr/local/lib/python3.10/dist-packages/ultralytics/cfg/__init__.py", line 594, in entrypoint
    getattr(model, mode)(**overrides)  # default args from model
  File "/usr/local/lib/python3.10/dist-packages/ultralytics/engine/model.py", line 657, in train
    self.trainer.train()
  File "/usr/local/lib/python3.10/dist-packages/ultralytics/engine/trainer.py", line 213, in train
    self._do_train(world_size)
  File "/usr/local/lib/python3.10/dist-packages/ultralytics/engine/trainer.py", line 454, in _do_train
    self.run_callbacks("on_fit_epoch_end")
  File "/usr/local/lib/python3.10/dist-packages/ultralytics/engine/trainer.py", line 176, in run_callbacks
    callback(self)
  File "/usr/local/lib/python3.10/dist-packages/ultralytics/utils/callbacks/raytune.py", line 17, in on_fit_epoch_end
    if ray.tune.is_session_enabled():
AttributeError: module 'ray.tune' has no attribute 'is_session_enabled'

```

**Changes I Made:**  
- In the file `ultralytics/utils/callbacks/raytune.py`, update the call:
  ```python
    if ray.tune.is_session_enabled():
  ```
  to:
  ```python
  if ray.train._internal.session.get_session():
  ```
- This change ensures compatibility with Ray versions >=2.41.0.

**Testing:**  
- Verified that the training pipeline now runs without the AttributeError on Ray v2.41.0.
- Confirmed that callbacks reporting training metrics to Ray Tune work as expected.

**Additional Notes:**  
- Ray version can alternatively downgrade Ray (e.g., to version 2.40.0) as a temporary workaround.

Please review and merge if everything looks good.

---