### PR TITLE
Fix torch.load

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -730,7 +730,7 @@ def torch_safe_load(weight):
                 "ultralytics.yolo.data": "ultralytics.data",
             }
         ):  # for legacy 8.0 Classify and Pose models
-            ckpt = torch.load(file, map_location="cpu")
+            ckpt = torch.load(file, map_location="cpu", weights_only=False)
 
     except ModuleNotFoundError as e:  # e.name is missing module name
         if e.name == "models":


### PR DESCRIPTION
Weights only load failed. Changed `torch.load(file, map_location=cpu)` to `torch.load(file, map_location=cpu, weights_only=False)`. Resolves #523. Credit goes to @allansdefreitas.